### PR TITLE
fix(ci): install uv before running make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: setup-docker
         uses: docker/setup-buildx-action@v3
 
+      - name: setup-uv
+        uses: astral-sh/setup-uv@v6
+
       - name: make cv.pdf
         run: make cv.pdf
       - name: make cv.json

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Build cv.json
         run: make cv.json
 
@@ -33,7 +36,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 20
+          node-version: 24
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies


### PR DESCRIPTION
uv is required by expand_includes.py (Makefile target build/cv.yml) but was not available on the GitHub Actions runner.