### PR TITLE
fix(ci): create web/src/data/ before copying cv.json

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -30,7 +30,7 @@ jobs:
         run: make cv.json
 
       - name: Sync cv.json to web
-        run: cp build/cv.json web/src/data/cv.json
+        run: mkdir -p web/src/data && cp build/cv.json web/src/data/cv.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- `web/src/data/cv.json` is gitignored so the directory doesn't exist on the runner
- Fix: `mkdir -p web/src/data` before `cp build/cv.json`

## Root cause
`web/src/data/` contains only gitignored files (`cv.json`, `content-seed.txt`), so the directory is absent on a fresh checkout.

## Test plan
- [x] Deploy Web workflow completes the "Sync cv.json to web" step