### PR TITLE
fix(make): replace ingy/yaml-to-json Docker with uv+pyyaml for cv.json

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
 
@@ -36,7 +33,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 24
+          node-version: lts/*
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ cv_full.pdf: clean init appendix.pdf cv.pdf
 	test -e ./build/appendix.pdf && pdfunite build/cv.pdf build/appendix.pdf build/cv_with_appendix.pdf || exit 0
 
 cv.json: build/cv.yml init
-	cat build/cv.yml | $(YAML_TO_JSON) | tee build/cv.json
+	uv run --with pyyaml python3 -c \
+		"import yaml, json, pathlib, datetime; print(json.dumps(yaml.safe_load(pathlib.Path('build/cv.yml').read_text()), default=lambda o: o.isoformat() if isinstance(o, (datetime.date, datetime.datetime)) else str(o)))" \
+		> build/cv.json
 
 # Web targets
 web: build/cv.json


### PR DESCRIPTION
## Summary
- `ingy/yaml-to-json` Docker image produces empty output silently in CI pipe — replaced with `uv+pyyaml` which is already available
- Added `datetime.date` serializer — PyYAML parses date strings as `datetime.date` objects which `json.dumps` can't handle by default
- Removed Docker Buildx from deploy-web workflow (not needed for `cv.json`)
- Node pinned to `lts/*` instead of hardcoded `24`

## Test plan
- [ ] `make cv.json` runs locally without errors
- [ ] `build/cv.json` is valid non-empty JSON
- [ ] Deploy Web workflow builds and deploys successfully