### PR TITLE
fix(make): add build/cv.json target so make web dependency chain works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ cv.pdf: build/cv.yml init build_docker
 cv_full.pdf: clean init appendix.pdf cv.pdf
 	test -e ./build/appendix.pdf && pdfunite build/cv.pdf build/appendix.pdf build/cv_with_appendix.pdf || exit 0
 
-cv.json: build/cv.yml init
+cv.json: build/cv.json
+
+build/cv.json: build/cv.yml init
 	uv run --with pyyaml python3 -c \
 		"import yaml, json, pathlib, datetime; print(json.dumps(yaml.safe_load(pathlib.Path('build/cv.yml').read_text()), default=lambda o: o.isoformat() if isinstance(o, (datetime.date, datetime.datetime)) else str(o)))" \
 		> build/cv.json


### PR DESCRIPTION
## Summary
- `make web` depends on `build/cv.json` (file path) but the target was named `cv.json` (phony) — make couldn't resolve the dependency and errored with "No rule to make target"
- Fix: rename the real build target to `build/cv.json`, keep `cv.json` as a phony alias for backwards compatibility

## Test plan
- [x] `make clean && make web` builds successfully locally
- [x] Deploy Web workflow passes on master
- [x] Photos visible on https://kornicameister.github.io/CV/