### PR TITLE
fix(web): fix avatar-dev.png 404 on GitHub Pages

### DIFF
--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -29,7 +29,8 @@ const normalizedPhotoUrl = photoUrl.startsWith('./') ? photoUrl.slice(1) : photo
 const fullPhotoUrl = normalizedPhotoUrl.startsWith(baseUrl) ? normalizedPhotoUrl : `${baseUrl}${normalizedPhotoUrl}`;
 
 // Second avatar for hover effect
-const avatarDevUrl = `${baseUrl}media/avatar-dev.png`;
+const baseUrlWithSlash = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+const avatarDevUrl = `${baseUrlWithSlash}media/avatar-dev.png`;
 
 // Read content seed for geometric pattern generation
 let seed = 12345; // fallback


### PR DESCRIPTION
## Summary

- `BASE_URL` is `/CV` (no trailing slash) in the Astro GitHub Pages config
- `${baseUrl}media/avatar-dev.png` was producing `/CVmedia/avatar-dev.png` — a 404
- Added a `baseUrlWithSlash` helper that ensures the slash before concatenating the media path, giving `/CV/media/avatar-dev.png`

## Test plan

- [ ] Verify the deployed site shows the developer avatar on hover (hover over the profile photo)
- [ ] Check no 404 for `https://kornicameister.github.io/CV/media/avatar-dev.png` in DevTools Network tab