### PR TITLE
fix(web): scroll to top of experience entry when accordion opens

### DIFF
--- a/web/src/components/Experience.astro
+++ b/web/src/components/Experience.astro
@@ -112,6 +112,10 @@ function formatDate(dateStr: string | number): string {
         if (!isExpanded) {
           newHeader.setAttribute('aria-expanded', 'true');
           content?.classList.add('expanded');
+          const timelineItem = newHeader.closest('.timeline-item');
+          requestAnimationFrame(() => {
+            (timelineItem || newHeader).scrollIntoView({ behavior: 'smooth', block: 'start' });
+          });
         }
       });
     });


### PR DESCRIPTION
## Summary
- Clicking an experience accordion header now scrolls the top of that entry into view
- Uses `scrollIntoView({ behavior: 'smooth', block: 'start' })` inside `requestAnimationFrame` so the scroll runs after the DOM updates
- Scroll only triggers on open, not on close

## Test plan
- [ ] Click a collapsed experience entry — page should smoothly scroll so the header is at the top of the viewport
- [ ] Close an entry — no scroll should happen
- [ ] Works on mobile viewport as well