### PR TITLE
fix(web): scroll to top of experience entry after accordion transition ends

### DIFF
--- a/web/src/components/Experience.astro
+++ b/web/src/components/Experience.astro
@@ -112,10 +112,14 @@ function formatDate(dateStr: string | number): string {
         if (!isExpanded) {
           newHeader.setAttribute('aria-expanded', 'true');
           content?.classList.add('expanded');
-          const timelineItem = newHeader.closest('.timeline-item');
-          requestAnimationFrame(() => {
-            (timelineItem || newHeader).scrollIntoView({ behavior: 'smooth', block: 'start' });
-          });
+          const timelineItem = newHeader.closest('.timeline-item') as Element;
+          const target = timelineItem || newHeader;
+          const onTransitionEnd = (ev: Event) => {
+            if ((ev as TransitionEvent).propertyName !== 'max-height') return;
+            content?.removeEventListener('transitionend', onTransitionEnd);
+            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          };
+          content?.addEventListener('transitionend', onTransitionEnd);
         }
       });
     });


### PR DESCRIPTION
## Summary
- Fixes chaotic scroll behaviour on mobile when clicking an experience entry
- Previous fix fired `scrollIntoView` during the `max-height` CSS transition, causing the two animations to fight each other
- Now waits for the `transitionend` event on `max-height` before scrolling — layout is stable by then

## Root cause
`requestAnimationFrame` fires one frame after DOM change, but the accordion `max-height` transition takes 400ms. Scrolling mid-transition on mobile is janky because the browser is still reflowing the expanding content.

## Test plan
- [ ] Click a collapsed experience entry — page should smoothly scroll the header to the top of the viewport **after** the entry finishes expanding
- [ ] Close an entry — no scroll should happen
- [ ] Works on mobile (the original reported issue)