### PR TITLE
chore(workspace): add Claude Code workspace setup

### DIFF
--- a/.claude/.codebase-info/.map-state.json
+++ b/.claude/.codebase-info/.map-state.json
@@ -1,0 +1,15 @@
+{
+  "tool": "codebase-mapper",
+  "version": "2.4.0",
+  "mappedAt": "2026-07-13",
+  "gitCommit": "ecea920c1edcc695e044cc49e73d1e9d5b99601f",
+  "documents": [
+    "INDEX.md",
+    "architecture.md",
+    "tech-landscape.md",
+    "directory-structure.md",
+    "entry-points.md",
+    "patterns.md",
+    "onboarding.md"
+  ]
+}

--- a/.claude/.codebase-info/INDEX.md
+++ b/.claude/.codebase-info/INDEX.md
@@ -1,0 +1,34 @@
+# CV — Codebase Map
+
+*Last Updated: 2026-07-13*
+
+A CV/resume generation system for Tomasz Trębski (Lead Software Developer). Produces a PDF via
+Pandoc + XeLaTeX and a static Astro web SPA from the same YAML source data.
+
+## Docs
+
+| Doc | What it covers |
+|-----|---------------|
+| [architecture.md](architecture.md) | System overview, components, data flow |
+| [tech-landscape.md](tech-landscape.md) | Languages, frameworks, runtimes, tooling |
+| [directory-structure.md](directory-structure.md) | Annotated folder tree |
+| [entry-points.md](entry-points.md) | Where builds and the web app begin |
+| [patterns.md](patterns.md) | Build patterns, YAML conventions, CI/CD |
+| [onboarding.md](onboarding.md) | Quick start, common tasks |
+
+## Quick orientation
+
+- Source data: `data/**/*.yml` composed via `cv.yml` with `!include` directives
+- PDF build: `make cv.pdf` (Docker + Pandoc + XeLaTeX, no local LaTeX needed)
+- Web build: `make web` → `cd web && npm run build` (Astro SPA)
+- Python tooling: `uv run expand_includes.py cv.yml` resolves `!include` before Pandoc
+
+## How to use this map
+
+Read `INDEX.md` for orientation. Open specific docs when working in that area. The
+`codebase-mapper` plugin injects this file on every prompt.
+
+## How to maintain this map
+
+Update the relevant doc when you change an area. Run `/codebase-mapper:update-codebase-map` after
+significant changes. Commit `.claude/.codebase-info/` so the whole team shares it.

--- a/.claude/.codebase-info/architecture.md
+++ b/.claude/.codebase-info/architecture.md
@@ -1,0 +1,59 @@
+# Architecture
+
+*Last Updated: 2026-07-13*
+
+## Overview
+
+Two independent output pipelines share one YAML source:
+
+```
+data/**/*.yml
+     │
+     └─ cv.yml (!include composition)
+          │
+          ├─ expand_includes.py ──► build/cv.yml
+          │                              │
+          │               ┌─────────────┴──────────────┐
+          │               │                            │
+          │     Pandoc+XeLaTeX (Docker)      Python yaml→json
+          │               │                            │
+          │          build/cv.pdf              build/cv.json
+          │                                         │
+          │                                  web/src/data/cv.json
+          │                                         │
+          │                                  Astro SPA (web/)
+          │                                         │
+          │                              web/dist/ (static site)
+          │
+          └─ (also produces build/cv.json for web)
+```
+
+## Components
+
+| Component | Path | Role |
+|-----------|------|------|
+| Data layer | `data/` | YAML source-of-truth for all CV content |
+| Composition file | `cv.yml` | Assembles sections via `!include`; the only file Pandoc/build sees |
+| Include expander | `expand_includes.py` | Resolves non-standard `!include` YAML directives recursively |
+| LaTeX template | `template/cv.tex` | Awesome-CV template; maps YAML keys to LaTeX macros |
+| Pandoc container | `Dockerfile` | `pandoc/extra` base + fontawesome6, roboto, xelatex |
+| Web frontend | `web/` | Astro SPA; reads `cv.json` at build time, no server-side rendering |
+
+## Data flow — PDF
+
+1. `make cv.pdf` triggers `build/cv.yml` target
+2. `uv run expand_includes.py cv.yml > build/cv.yml` — all `!include` directives resolved
+3. Docker runs `pandoc` with `--pdf-engine=xelatex --template=template/cv.tex`
+4. Output: `build/cv.pdf`
+
+## Data flow — Web
+
+1. `make web` triggers `build/cv.json` target first
+2. Python one-liner converts `build/cv.yml` → `build/cv.json` (handles `date` → ISO string)
+3. `cp build/cv.json web/src/data/cv.json` (also copies `media/` → `web/public/media/`)
+4. `cd web && npm run build` — Astro static build → `web/dist/`
+
+## Deployment
+
+- PDF: GitHub Release artifact (on `v*` tags)
+- Web: GitHub Pages via `deploy-web.yml` workflow, published at `https://kornicameister.github.io/CV`

--- a/.claude/.codebase-info/directory-structure.md
+++ b/.claude/.codebase-info/directory-structure.md
@@ -1,0 +1,70 @@
+# Directory Structure
+
+*Last Updated: 2026-07-13*
+
+```
+CV/
+├── cv.yml                   # Top-level composition file (uses !include)
+├── cv.yml.backup            # Backup of original monolithic cv.yml
+├── metadata.yml             # Pandoc metadata (passed alongside cv.yml)
+├── Makefile                 # All build targets
+├── Dockerfile               # Pandoc+XeLaTeX container
+├── expand_includes.py       # !include resolver (uv run expand_includes.py cv.yml)
+├── pyproject.toml           # Python project config
+├── uv.lock                  # Locked Python deps
+├── awesome-cv.cls           # LaTeX document class (bundled, don't modify)
+│
+├── data/                    # CV content — one file per logical unit
+│   ├── basic.yml            # Name, position, photo URL
+│   ├── contact.yml          # Address, email
+│   ├── social.yml           # LinkedIn, GitHub, etc.
+│   ├── rodo.yml             # GDPR compliance text (always keep in output)
+│   ├── experience/          # One .yml per employer
+│   ├── skills/              # One .yml per skill category
+│   ├── education/           # One .yml per degree
+│   ├── certifications/      # One .yml per cert
+│   ├── presentations/       # Conference talks
+│   ├── articles/            # Published articles
+│   └── oss/                 # Open source contributions
+│
+├── template/                # LaTeX templates
+│   ├── cv.tex               # Main Pandoc template (maps YAML vars → LaTeX)
+│   ├── cv_before.tex        # Included before appendix body
+│   └── cv_after.tex         # Included after appendix body
+│
+├── fonts/                   # Roboto + FontAwesome TTFs (used by XeLaTeX)
+│
+├── media/                   # Photos
+│   ├── profile.png          # Used in PDF
+│   └── avatar-dev.png       # Used in web
+│
+├── build/                   # Generated artifacts (gitignored)
+│   ├── cv.yml               # Expanded (include-resolved) YAML
+│   ├── cv.pdf               # Final PDF
+│   └── cv.json              # JSON for web consumption
+│
+├── web/                     # Astro SPA frontend (separate Node project)
+│   ├── astro.config.mjs     # Astro config (base: '/CV', GitHub Pages)
+│   ├── package.json         # Node deps (Astro ^7)
+│   ├── src/
+│   │   ├── pages/index.astro    # Single page, imports all components
+│   │   ├── layouts/             # BaseLayout.astro
+│   │   ├── components/          # Hero, Experience, Skills, Education, etc.
+│   │   ├── styles/global.css    # Global styles
+│   │   └── data/cv.json         # Generated (gitignored), copied from build/
+│   └── public/              # Static assets (favicon, media/)
+│
+├── .github/workflows/       # CI/CD
+│   ├── ci.yml               # Prettier + PDF/JSON build
+│   ├── release.yml          # Creates GitHub Release on v* tags
+│   └── deploy-web.yml       # Deploys web/ to GitHub Pages
+│
+└── specs/                   # Design notes / architecture decisions
+    └── yaml-include-solution.md
+```
+
+## Key invariant
+
+`cv.yml` uses non-standard `!include` directives and **must** be processed through
+`expand_includes.py` before any YAML parser sees it. Never pass `cv.yml` directly to
+`yaml.safe_load` or similar.

--- a/.claude/.codebase-info/entry-points.md
+++ b/.claude/.codebase-info/entry-points.md
@@ -1,0 +1,34 @@
+# Entry Points
+
+*Last Updated: 2026-07-13*
+
+## Build entry points
+
+| Target | Command | What it does |
+|--------|---------|-------------|
+| PDF | `make cv.pdf` | Full PDF build: expand → pandoc+xelatex → `build/cv.pdf` |
+| JSON only | `make cv.json` | YAML → JSON → `build/cv.json` |
+| Web | `make web` | JSON + Astro build → `web/dist/` |
+| Full CV with appendix | `make cv_full.pdf` | PDF + appendix.md joined with pdfunite |
+| Docker image | `make build_docker` | Builds `pandoc:latest` from `Dockerfile` |
+| Clean | `make clean` | Removes `build/`, `web/dist/`, `web/src/data/cv.json`, `web/public/media/` |
+
+## Python entry point
+
+`expand_includes.py` — called as `uv run expand_includes.py cv.yml > build/cv.yml`.
+Recursively resolves `!include <path>` directives. No arguments beyond the input file.
+
+## Web entry point
+
+`web/src/pages/index.astro` — the single page of the SPA.
+- Imports `cv.json` at build time
+- Renders: `Hero` → `Experience` → `Certifications` → `Skills` → `Education` + `NavIndicator`
+- Client-side scroll-spy updates URL hash and nav dots
+
+## CI/CD entry points
+
+| Trigger | Workflow | Result |
+|---------|----------|--------|
+| Push/PR to `master` | `.github/workflows/ci.yml` | Prettier check → PDF/JSON build → artifact upload |
+| `v*` tag push | `.github/workflows/release.yml` | GitHub Release with PDF/JSON attached |
+| Push to `master` | `.github/workflows/deploy-web.yml` | Web SPA deployed to GitHub Pages |

--- a/.claude/.codebase-info/onboarding.md
+++ b/.claude/.codebase-info/onboarding.md
@@ -1,0 +1,65 @@
+# Onboarding
+
+*Last Updated: 2026-07-13*
+
+## Prerequisites
+
+- Docker (for Pandoc/XeLaTeX and yaml-to-json)
+- `uv` (Python tool runner — no virtualenv needed)
+- Node.js ≥18 + npm (for the Astro web frontend)
+
+No local LaTeX installation required.
+
+## Quick start
+
+```bash
+# 1. Build the PDF (most common)
+make cv.pdf               # → build/cv.pdf
+
+# 2. Build just the JSON
+make cv.json              # → build/cv.json
+
+# 3. Build the web frontend
+make web                  # → web/dist/
+
+# 4. (Re)build the Docker image if dependencies changed
+make build_docker
+
+# 5. Preview the web locally
+cd web && npm run dev     # → http://localhost:4321/CV
+```
+
+## Common tasks
+
+### Add a new experience entry
+
+1. Create `data/experience/<company-slug>.yml` with the schema in `patterns.md`
+2. Add `  - !include data/experience/<company-slug>.yml` to `cv.yml` under `experience:`
+3. Run `make cv.pdf` to verify it renders
+
+### Add a new skill category
+
+1. Create `data/skills/<name>.yml` with `name:` and `items:` keys
+2. Add `  - !include data/skills/<name>.yml` to `cv.yml` under `skill:`
+
+### Edit existing content
+
+Edit the relevant file in `data/`. Changes propagate on next `make` invocation.
+
+### Update the web frontend
+
+Components live in `web/src/components/`. The page is `web/src/pages/index.astro`.
+Run `cd web && npm run dev` for hot-reload during development.
+
+### Debug a broken PDF build
+
+1. Check `build/cv.yml` was generated: `make build/cv.yml`
+2. Inspect it — if `!include` directives are still present, `expand_includes.py` failed
+3. Verify Docker image exists: `docker images pandoc`
+4. LaTeX errors appear in Pandoc stdout
+
+## CI
+
+Push to `master` or open a PR → CI checks prettier on `cv.yml`, builds PDF + JSON, uploads as artifact.
+Tag `v*` → Release workflow creates a GitHub Release with PDF and JSON.
+Push to `master` (after merge) → Astro site deployed to GitHub Pages.

--- a/.claude/.codebase-info/patterns.md
+++ b/.claude/.codebase-info/patterns.md
@@ -1,0 +1,79 @@
+# Patterns & Conventions
+
+*Last Updated: 2026-07-13*
+
+## YAML composition pattern
+
+`cv.yml` is the only file Pandoc or the build pipeline ever reads. It composes data via
+non-standard `!include` directives:
+
+```yaml
+basic: !include data/basic.yml
+experience:
+  - !include data/experience/lcloud.yml
+```
+
+`expand_includes.py` resolves these recursively before any downstream tool sees the YAML.
+**Never run a YAML parser on `cv.yml` directly.**
+
+## Data entry schema
+
+### Experience entry (`data/experience/<company>.yml`)
+```yaml
+start: MM.YYYY
+end: MM.YYYY  # or "now"
+position: Job Title
+company: Company Name
+city: Location
+tasks:
+  - project: Project Name
+    entries:
+      - bullet point
+```
+
+### Skill category (`data/skills/<name>.yml`)
+```yaml
+name: Category Name
+items: [skill1, skill2]
+```
+
+## Build determinism
+
+- Prettier enforced on `cv.yml` in CI (`--check` only, no autofix)
+- Python deps locked via `uv.lock` — always use `uv run` to ensure reproducibility
+- Docker image tag `pandoc:latest` is local; rebuilt with `make build_docker`
+
+## JSON date handling
+
+The YAML→JSON conversion uses a Python one-liner that serializes `datetime.date`/`datetime.datetime`
+to ISO strings via `default=lambda o: o.isoformat()`. YAML date values (e.g. `2024-01-01`) become
+JSON strings.
+
+## Web data flow
+
+`make web` does:
+1. Copies `build/cv.json` → `web/src/data/cv.json`
+2. Copies `media/*` → `web/public/media/`
+3. Writes a `content-seed.txt` (SHA of all `data/` files) for cache-busting
+4. Runs `npm run build` in `web/`
+
+`web/src/data/cv.json` and `web/public/media/` are both gitignored — always generated.
+
+## Astro component pattern
+
+Components are pure Astro (`.astro`), typed with TypeScript interfaces in the frontmatter.
+No framework (React/Vue/Svelte) is used — just Astro's island architecture with `<ClientRouter>`
+for view transitions. Client-side JS lives in `<script>` blocks in `index.astro`.
+
+## Error handling
+
+`expand_includes.py` prints a warning to stderr for missing includes and returns the raw
+`!include` directive unchanged — allowing the build to continue but making the output incorrect.
+Treat any warning from this script as a build failure.
+
+## CI/CD
+
+- All jobs on `ubuntu-latest`
+- `uv` installed via `astral-sh/setup-uv@v6`
+- Docker via `docker/setup-buildx-action@v3`
+- Artifacts uploaded with `actions/upload-artifact@v4` (named `cv_<sha>_build`)

--- a/.claude/.codebase-info/structure.md
+++ b/.claude/.codebase-info/structure.md
@@ -1,0 +1,44 @@
+# Project structure — CV
+
+## Purpose
+
+A CV/resume generation system that maintains source data in modular YAML files and produces:
+- PDF output via Pandoc + XeLaTeX in Docker (the primary artifact)
+- JSON output for the web frontend
+- An Astro-based static site (`web/`) that renders the CV as a SPA
+
+## Organizing principle
+
+**Data lives in `data/`, presentation lives in `template/`, web in `web/`, build artifacts in `build/`.**
+Nothing generated belongs in the root or `data/` directories.
+
+## Where things go
+
+| What | Where |
+|------|-------|
+| CV content (jobs, skills, education, etc.) | `data/<section>/<entry>.yml` |
+| Top-level YAML composition | `cv.yml` (uses `!include` directives) |
+| LaTeX template | `template/cv.tex` + `awesome-cv.cls` |
+| Fonts for PDF | `fonts/` |
+| Astro frontend source | `web/src/` |
+| Web data (generated JSON) | `web/src/data/cv.json` (generated, gitignored) |
+| Build artifacts (PDF, JSON) | `build/` (gitignored) |
+| Media/photos | `media/` |
+| GitHub Actions workflows | `.github/workflows/` |
+| Python tooling (`expand_includes.py`) | repo root |
+
+## Build pipeline
+
+1. `expand_includes.py` resolves `!include` in `cv.yml` → `build/cv.yml`
+2. Pandoc (Docker) + XeLaTeX → `build/cv.pdf`
+3. `yaml-to-json` (Docker) → `build/cv.json` → copied to `web/src/data/cv.json`
+4. Astro (`web/`) builds the SPA from `cv.json`
+
+All builds go through `make`. No local LaTeX installation needed.
+
+## Key constraints
+
+- `cv.yml` uses a non-standard `!include` YAML directive — never pass it raw to a YAML parser without
+  running `expand_includes.py` first.
+- The Astro site at `web/` is a separate Node project (`web/package.json`) but lives in the same repo.
+- GDPR compliance text is in `data/rodo.yml` — always keep it in the output.

--- a/.claude/.codebase-info/tech-landscape.md
+++ b/.claude/.codebase-info/tech-landscape.md
@@ -1,0 +1,46 @@
+# Tech Landscape
+
+*Last Updated: 2026-07-13*
+
+## Languages & runtimes
+
+| Language | Version | Use |
+|----------|---------|-----|
+| Python | ≥3.11 | `expand_includes.py`, YAML→JSON conversion |
+| TypeScript | via Node ≥18 | Astro components (`web/src/`) |
+| LaTeX (XeLaTeX) | via Docker | PDF rendering |
+
+## Frameworks & tools
+
+| Tool | Version | Role |
+|------|---------|------|
+| Astro | ^7.0.3 | Static site framework for `web/` |
+| Pandoc | Docker (`pandoc/extra`) | Markdown+YAML → PDF conversion |
+| uv | latest | Python tool runner (`uv run --with pyyaml`) |
+| pyyaml | ≥6 | YAML parsing in Python tooling |
+| awesome-cv.cls | bundled | LaTeX document class for CV formatting |
+
+## Infrastructure
+
+| Platform | Use |
+|----------|-----|
+| Docker | Pandoc+XeLaTeX build environment; `ingy/yaml-to-json` for JSON conversion |
+| GitHub Actions | CI (prettier check, PDF/JSON build), web deploy, release |
+| GitHub Pages | Hosts the Astro SPA at `https://kornicameister.github.io/CV` |
+
+## Source-of-truth files
+
+| File | What it controls |
+|------|-----------------|
+| `cv.yml` | CV composition (section order, included entries) |
+| `pyproject.toml` | Python project config + dependencies |
+| `uv.lock` | Locked Python deps |
+| `web/package.json` | Node/Astro deps for web frontend |
+| `Dockerfile` | Pandoc container definition |
+| `Makefile` | All build targets |
+| `.prettierrc` | YAML formatting rules (checked in CI) |
+
+## Fonts
+
+Roboto (Light, Regular, Medium, Bold, Thin + Italic variants) + FontAwesome bundled in `fonts/`.
+Loaded by XeLaTeX via the template.

--- a/.claude/live-rules.md
+++ b/.claude/live-rules.md
@@ -1,0 +1,118 @@
+# Live rules — CV
+# Injected automatically by the live-rules plugin. Global rules fire every prompt;
+# scoped rules fire when their files/keywords match. Keep each body tight — all rules
+# matching one event share a ~10k-char budget. Anything above the first `---` fence is ignored.
+# Edit freely; changes take effect on the next prompt. Commit this file so the team shares it.
+
+---
+description: Atomic commits & two hats
+priority: 95
+---
+- One logical, self-contained change per commit; never bundle unrelated changes (a feature, a
+  refactor, and a doc fix are three commits). Split by dependency order.
+- Two hats: a commit either *adds behavior* (ships with its test) or *refactors*
+  (behavior-preserving) — never both in one commit.
+- Stage deliberately, per path or per hunk; never blind-add everything at once.
+- Commit at each finished, green step. Commit only when asked; don't push unless asked. On the
+  default branch, create a working branch first. Never amend published commits, never skip hooks.
+
+---
+description: Simple design & small reversible steps (Beck / Fowler)
+priority: 90
+---
+Wear one hat at a time; small reversible steps, re-check between moves. Separate a behavior change
+(pin with a test) from a refactor (behavior-preserving) — never fold tidy-up into a behavior change.
+Beck's order: 1) passes tests, 2) reveals intention, 3) no duplication, 4) fewest elements (YAGNI).
+Ties break toward clarity. Leave each file cleaner than you found it — as its own step.
+
+---
+description: Surgical, simple, honest
+priority: 90
+---
+- Think before coding: state assumptions, surface ambiguity, push back on overcomplication. A wrong
+  guess costs more than a question — ask instead of silently picking a reading.
+- Simplicity first: the minimum code that solves it. No speculative abstractions, no "flexibility"
+  nobody asked for, no error handling for impossible states.
+- Surgical: every changed line traces to the request. Don't "improve" adjacent code or refactor what
+  isn't broken; match the existing style. Remove only the dead code your change created.
+- Define "done" and verify it before calling a change finished.
+
+---
+description: Verify behavior deterministically
+priority: 85
+---
+- Prove changes by exercising them — a script that asserts, a test, a real run whose output you show —
+  not by eyeballing that it "looks right". Round-trip harnesses, diffs, exact-equality checks, counts.
+- A change isn't "done" until a deterministic check passes and its output is shown.
+
+---
+description: House code conventions
+priority: 80
+---
+- No inline comments unless they capture a real hidden constraint (a *why* the code can't express).
+  Lean on naming and structure, not narration. Delete commented-out code.
+- Replace magic numbers with named constants. Match the surrounding code's idiom, naming, and
+  comment density.
+
+---
+description: Commit messages state only what you verified
+priority: 87
+---
+- Every technical claim in a commit message must be something you actually observed or reproduced,
+  not a plausible guess. An honest "cause not yet confirmed" beats an invented root cause.
+- Describe what changed and why; don't narrate a fix you didn't verify.
+
+---
+description: Refactoring discipline (Fowler)
+prompt: ["refactor", "refactoring", "clean up", "cleanup", "tidy", "restructure"]
+priority: 45
+---
+Refactoring changes structure, never behavior — and only starts from green (add a characterization
+test first if needed). Name the smell, then apply the matching small named move (extract function,
+rename, parameter object…), running tests after each. No behavior changes or features folded in —
+separate commits. Many tiny safe moves beat one big rewrite.
+
+---
+description: Responsibility-driven Python & API design (Metz / Wirfs-Brock / Bloch)
+globs: ["**/*.py"]
+priority: 50
+---
+- One clear responsibility per function/class, named for its role (not its data).
+- Tell, don't ask; talk to friends, not strangers (Demeter). Guard clauses over deep nesting.
+- Metz targets, justify any break: methods ~5 lines, classes ~100, ≤4 params.
+- Isolate external deps (the network, the clock, RNG, heavy libs) behind small seams so core logic
+  stays pure and testable. Validate at boundaries; prefer immutable value objects.
+- Public API is a contract (Bloch): start private, widen only when needed. Log via a real logger,
+  never `print()`.
+
+---
+description: Python testing discipline
+globs: ["**/tests/**", "**/test_*.py", "**/*_test.py", "**/conftest.py"]
+priority: 55
+---
+- Red → Green → Refactor. One behavior per test; Arrange-Act-Assert; name `test_<situation>_<expected>`.
+- Add a characterization test before changing untested logic. Tests mirror the source tree.
+
+---
+description: Verify framework behavior against docs, not memory
+prompt: ["api", "version", "does astro", "does uv", "does pyyaml", "how does", "the docs"]
+priority: 70
+---
+- For a library/framework/CLI whose behavior you're about to assert, verify against context7 (or the
+  project's docs) before claiming an API works a certain way — training data lags releases.
+- Record durable, verified facts in the codebase map so the next session doesn't re-check.
+
+---
+description: Self-improvement — turn friction into a fix that sticks
+priority: 40
+---
+After finishing a chunk of work, take a beat: did you hit friction? Signs — you fumbled the stack or
+its tooling, re-derived something that should've been written down, tripped over a missing or unclear
+convention, guessed wrong about where code lives, or repeated a workaround. If so, don't just move on:
+make that friction cheaper or impossible next time by improving the workspace itself.
+- Wrong/missing convention → add or refine a **live rule** (scope it tightly).
+- Stale or missing project knowledge → update the **codebase map** (`.claude/.codebase-info/`).
+- A repeatable multi-step task you did by hand → propose a **skill** (via skill-creator).
+- A durable project fact or decision → into **CLAUDE.md** or a map doc.
+Keep it small and incremental — one improvement, not a rewrite. Do it as its own step/commit. If
+nothing was off, skip it silently; don't manufacture busywork. For a deeper periodic pass, run `retro`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,13 @@
 {
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "codebase-mapper@eigenwise-toolshed": true,
+    "live-rules@eigenwise-toolshed": true,
+    "playwright@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "eigenwise-toolshed": {
+      "source": { "source": "github", "repo": "Eigenwise/eigenwise-toolshed" }
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,10 @@ appendix.md
 
 build/
 specs/
+
+# Claude Code — shared workspace config (override global gitignore)
+!.claude/
+!.claude/**
+# but keep local/machine-specific files out
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/` workspace config committed to the repo so every session and contributor shares the same setup
- `.claude/settings.json` — enables `codebase-mapper`, `live-rules`, `playwright`, `frontend-design` plugins + eigenwise-toolshed marketplace
- `.claude/live-rules.md` — craft baseline rules (atomic commits, simple design, surgical changes, verify-before-done) + Python rules + self-improvement loop
- `.claude/.codebase-info/` — codebase map: architecture, tech-landscape, directory-structure, entry-points, patterns, onboarding
- `.gitignore` updated to un-ignore `.claude/` shared files while keeping `settings.local.json` and `worktrees/` local-only

## Test plan

- [ ] CI passes (prettier + PDF/JSON build)
- [ ] No new files leaked that should be gitignored (`settings.local.json`, `worktrees/`)