### PR TITLE
fix(ci): upgrade setup-uv v6 → v8 to eliminate node20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     needs: [verify]
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - name: run unit tests
         run: uv run --with boto3 --with pytest pytest scripts/test_translate_cv.py -v
 
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: setup-uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: make cv.pdf
         run: make cv.pdf
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: setup-uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     needs: [verify]
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
       - name: run unit tests
         run: uv run --with boto3 --with pytest pytest scripts/test_translate_cv.py -v
 
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: setup-uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: make cv.pdf
         run: make cv.pdf
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: setup-uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
astral-sh/setup-uv@v6 targets Node.js 20 which is deprecated on GitHub Actions runners. v8 targets Node.js 24.