### PR TITLE
fix(iac): add foundation model ARN for cross-region inference profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ cv.json: build/cv.json
 cv.eng.json: build/cv.eng.json
 cv.pl.json: build/cv.pl.json
 
-iac/deploy: iac/oidc-bedrock.yml iac/.env
+iac: iac/oidc-bedrock.yml iac/.env
 	aws cloudformation deploy \
 		--template-file iac/oidc-bedrock.yml \
 		--stack-name cv-translator-oidc \

--- a/iac/oidc-bedrock.yml
+++ b/iac/oidc-bedrock.yml
@@ -61,7 +61,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: bedrock:InvokeModel
-                Resource: !Sub "arn:aws:bedrock:${BedrockRegion}:${AwsAccountId}:inference-profile/eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+                Resource:
+                  - !Sub "arn:aws:bedrock:${BedrockRegion}:${AwsAccountId}:inference-profile/eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+                  - "arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
 
 Outputs:
   RoleArn:


### PR DESCRIPTION
## Summary

- IAM policy was missing the foundation model ARN required for cross-region inference profile invocation
- AWS requires `bedrock:InvokeModel` on **both** the inference profile ARN and the underlying `foundation-model` ARN
- Added `arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0` to the resource list

## Root cause

Cross-region inference profiles (e.g. `eu.anthropic.claude-haiku-4-5-*`) route calls through multiple regional foundation model endpoints. The inference profile lookup succeeds but the actual model invocation was denied because the foundation model ARN was not in the policy.

## Test plan

- [x] CloudFormation stack `cv-translator-oidc` updated successfully
- [ ] Re-run CI on master — `translate-bedrock` job should pass `make cv.pl.json`