### PR TITLE
chore(data): remove physical address from cv

### DIFF
--- a/data/contact.yml
+++ b/data/contact.yml
@@ -1,3 +1,2 @@
-address: Niciarniana 13/4, 92-238 Łódź, Polska
 email: tomasz.trebski@gmail.com
 mobile: (+48) 789231312

--- a/template/cv.tex
+++ b/template/cv.tex
@@ -17,7 +17,6 @@
 \position{$basic.position$}
 
 % contact
-\address{$contact.address$}
 \email{$contact.email$}
 \mobile{$contact.mobile$}
 


### PR DESCRIPTION
## Summary

- Remove full street address from `data/contact.yml`
- Remove `\address{}` call from `template/cv.tex`

## Why

Full address adds no value — recruiters use email and phone to contact candidates. Publishing a precise home address on a public CV is a privacy risk with zero upside.

## Test plan

- [ ] Build `make cv.pdf` — address line should be absent from PDF header