### PR TITLE
Rewrite CV with outcome-focused bullets and add summary

### DIFF
--- a/data/basic.yml
+++ b/data/basic.yml
@@ -5,7 +5,7 @@ position: Lead Software Developer
 summary: |
   13+ years building backend systems and cloud infrastructure, most recently
   designing agentic AI systems on AWS Bedrock. Led teams at AppYourself and
-  Fujitsu delivering serverless architectures at scale. Strong track record of
-  reducing operational overhead through IaC and automation — CDK, CloudFormation,
-  GitHub Actions. Fluent in Python and TypeScript; comfortable from domain model
-  to IAM policy.
+  Fujitsu delivering serverless architectures at scale. Reduced operational
+  overhead repeatedly through IaC and automation: CDK, CloudFormation, GitHub
+  Actions. Fluent in Python and TypeScript; comfortable from domain model to
+  IAM policy.

--- a/data/basic.yml
+++ b/data/basic.yml
@@ -2,3 +2,10 @@ photoUrl: ./media/profile.png
 firstName: Tomasz
 lastName: Trębski
 position: Lead Software Developer
+summary: |
+  13+ years building backend systems and cloud infrastructure, most recently
+  designing agentic AI systems on AWS Bedrock. Led teams at AppYourself and
+  Fujitsu delivering serverless architectures at scale. Strong track record of
+  reducing operational overhead through IaC and automation — CDK, CloudFormation,
+  GitHub Actions. Fluent in Python and TypeScript; comfortable from domain model
+  to IAM policy.

--- a/data/experience/appyourself-sp-zoo.yml
+++ b/data/experience/appyourself-sp-zoo.yml
@@ -12,6 +12,10 @@ tasks:
     parallel E2E testing in maximum component isolation
   - designed the AWS organisation structure with CDK from day one, establishing the
     foundation all subsequent services built on
+  - bootstrapped AWS organisation across environments using CDK StackSets, providing
+    consistent account structure from day one
+  - built an internal dependency-update tool that propagated version changes automatically
+    across own components (not just 3rd-party), eliminating manual cross-service update steps
 - project: AY-OldGen
   entries:
   - eliminated email delivery and receiving failures by rebuilding the mail pipeline

--- a/data/experience/appyourself-sp-zoo.yml
+++ b/data/experience/appyourself-sp-zoo.yml
@@ -6,24 +6,25 @@ city: Łódź, Poland
 tasks:
 - project: AY-NextGen
   entries:
-  - event storming & DDD
-  - design documents
-  - technical documentation
-  - setting up AWS organization with AWS CDK
-  - microservice architecture
-  - building serverless components/services
-  - designed and implemented deployment model on top of NodeJS and AWS CDK
-  - supporting team with auxiliary DevOps tools
+  - shipped 6 microservices to production in 1+ year by architecting the full CDK-based
+    deployment model — pipelines, component integration, and environment isolation
+  - enabled every developer on the 7-person team to deploy independently, unlocking
+    parallel E2E testing in maximum component isolation
+  - designed the AWS organisation structure with CDK from day one, establishing the
+    foundation all subsequent services built on
 - project: AY-OldGen
   entries:
-  - migrating old monolithic stack into AWS-based environment
-  - improving/implementing monitoring for old/new features
-  - creating new features, using AWS services, to supplement existing services
-  - creating designs containing detailed feature analysis from requirements down to
-    cost assessments
+  - eliminated email delivery and receiving failures by rebuilding the mail pipeline
+    on AWS services, including lossless attachment handling
+  - reduced production incidents by migrating legacy monolith features to AWS-native
+    services with improved observability and monitoring
+  - created detailed feature designs with cost assessments from requirements down,
+    giving product owners decision-quality data before committing to builds
 - project: team specific
   entries:
-  - improving security posture by utilizing least privileged concept
-  - helping with Scrum adoption (Git and release workflow, documentation, planning)
-  - building awareness concerning an importance of documentation both preliminary
-    (designs) and final one
+  - reduced IAM over-privilege surface across services by applying least-privilege
+    concept to every role; introduced MFA for all 7 engineers
+  - laid groundwork for multi-account SSO access, improving long-term security posture
+    (work handed off at departure)
+  - accelerated Scrum adoption by establishing Git workflow, release process, and
+    documentation standards across the team

--- a/data/experience/appyourself-sp-zoo.yml
+++ b/data/experience/appyourself-sp-zoo.yml
@@ -7,27 +7,27 @@ tasks:
 - project: AY-NextGen
   entries:
   - shipped 6 microservices to production in 1+ year by architecting the full CDK-based
-    deployment model — pipelines, component integration, and environment isolation
-  - enabled every developer on the 7-person team to deploy independently, unlocking
-    parallel E2E testing in maximum component isolation
-  - designed the AWS organisation structure with CDK from day one, establishing the
+    deployment model covering pipelines, component integration, and environment isolation
+  - gave every developer on the 7-person team the ability to deploy independently,
+    which unlocked parallel E2E testing at maximum component isolation
+  - designed the AWS organisation structure with CDK from day one, providing the
     foundation all subsequent services built on
-  - bootstrapped AWS organisation across environments using CDK StackSets, providing
-    consistent account structure from day one
+  - bootstrapped AWS organisation across environments using CDK StackSets for
+    consistent account structure from the start
   - built an internal dependency-update tool that propagated version changes automatically
-    across own components (not just 3rd-party), eliminating manual cross-service update steps
+    across own components (not just 3rd-party), removing manual cross-service update steps
 - project: AY-OldGen
   entries:
   - eliminated email delivery and receiving failures by rebuilding the mail pipeline
     on AWS services, including lossless attachment handling
   - reduced production incidents by migrating legacy monolith features to AWS-native
-    services with improved observability and monitoring
-  - created detailed feature designs with cost assessments from requirements down,
+    services with better observability and monitoring
+  - wrote detailed feature designs with cost assessments from requirements down,
     giving product owners decision-quality data before committing to builds
 - project: team specific
   entries:
   - reduced IAM over-privilege surface across services by applying least-privilege
-    concept to every role; introduced MFA for all 7 engineers
+    to every role; introduced MFA for all 7 engineers
   - laid groundwork for multi-account SSO access, improving long-term security posture
     (work handed off at departure)
   - accelerated Scrum adoption by establishing Git workflow, release process, and

--- a/data/experience/appyourself-sp-zoo.yml
+++ b/data/experience/appyourself-sp-zoo.yml
@@ -10,6 +10,10 @@ tasks:
     deployment model covering pipelines, component integration, and environment isolation
   - gave every developer on the 7-person team the ability to deploy independently,
     which unlocked parallel E2E testing at maximum component isolation
+  - authored multiple specifications used powering the full-stack team to deliver coherent
+    implementation's vision
+  - introduced and succesfully implemented OpenAPI driven API development for public-to-service
+    and service-to-service paradigms
   - designed the AWS organisation structure with CDK from day one, providing the
     foundation all subsequent services built on
   - bootstrapped AWS organisation across environments using CDK StackSets for

--- a/data/experience/appyourself-sp-zoo.yml
+++ b/data/experience/appyourself-sp-zoo.yml
@@ -19,7 +19,8 @@ tasks:
 - project: AY-OldGen
   entries:
   - eliminated email delivery and receiving failures by rebuilding the mail pipeline
-    on AWS services, including lossless attachment handling
+    on AWS services, including effective attachment handling especially targeting
+    volume issues
   - reduced production incidents by migrating legacy monolith features to AWS-native
     services with better observability and monitoring
   - wrote detailed feature designs with cost assessments from requirements down,

--- a/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
+++ b/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
@@ -10,26 +10,25 @@ tasks:
     CloudFormation + Makefile orchestration, replacing manual cluster setup
   - enforced CloudFormation code-quality gates project-wide, catching configuration
     drift before it reached production
-  - uses various AWS components ranging from HA networking setup to advanced EC2 deployments
+  - stack spanned HA VPC networking, EMR, MSK, and manually-provisioned EC2 clusters due to project security restrictions
 - project: AWS Project 1 [proprietary]
   entries:
   - reduced IAM blast radius across the deployment by applying least-privilege principles
     to every Lambda execution role, enforced through GitHub Actions CI gates
-  - solution was based on REST API (Lambda) and UI (S3); CI/CD built on GitHub Actions
+  - serverless REST API (Lambda) and static UI (S3) deployed end-to-end with GitHub Actions CI/CD
 - project: EOS
   entries:
   - accelerated CI adoption across backend and frontend teams by introducing a shared
     pipeline setup, eliminating parallel divergent configurations
   - improved throughput of critical services through targeted profiling and optimisation
-  - participated in full life-cycle of features from product owner requests through
-    design to final implementation
+  - owned features end-to-end from product owner requirements through design to production, reducing handoff gaps
 - project: monasca
   entries:
   - authored monasca-log-api from scratch and maintained it as original owner, earning
     OpenStack core-reviewer status — one of fewer than 10 across the monasca org
   - eliminated log-pipeline setup friction for operators by building the dockerized
     monasca-log pipeline for monasca-docker, adopted by the community
-  - increased code quality for monasca projects by influencing proper CI setup
+  - raised monasca project CI standards by introducing gating pipelines that blocked merges on quality regressions
 - project: OpenService Catalog Manager
   entries:
   - unblocked the team from a deprecated runtime by migrating OSCm from Glassfish 2.x

--- a/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
+++ b/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
@@ -6,41 +6,31 @@ city: Łódź, Poland
 tasks:
 - project: AWS Project 2 [proprietary]
   entries:
-  - building multi-service deployment with CloudFormation
-  - project architecture based on Makefile (own idea)
+  - delivered reproducible multi-service AWS infrastructure (EMR, MSK, EC2 HA) using
+    CloudFormation + Makefile orchestration, replacing manual cluster setup
+  - enforced CloudFormation code-quality gates project-wide, catching configuration
+    drift before it reached production
   - uses various AWS components ranging from HA networking setup to advanced EC2 deployments
-  - due to project restrictions some of the clusters were manually deployed based
-    on EC2
-  - introduced project wide restrictions regarding code quality also for CloudFormation
-    templates
-  - EMR/MSK clusters setups
 - project: AWS Project 1 [proprietary]
   entries:
-  - building deployment with CloudFormation
-  - solution was based on REST Api (Lambda based) and UI (S3 based)
-  - CI/CD built in this project was based on Github Actions and Least Priviliged IAM
-    entity
+  - reduced IAM blast radius across the deployment by applying least-privilege principles
+    to every Lambda execution role, enforced through GitHub Actions CI gates
+  - solution was based on REST API (Lambda) and UI (S3); CI/CD built on GitHub Actions
 - project: EOS
   entries:
-  - maintaining, developing and supervising frontend application
-  - influencing better code quality for backend and frontend services by promoting
-    best practices and equivalent CI setup
-  - activities towards increasing the performance of critical services
-  - technical proposals about API management and maintenance
-  - supervising backend API health
-  - participating in full life-cycle of a features, from product owners' requests
-    to final implementation through design phase
+  - accelerated CI adoption across backend and frontend teams by introducing a shared
+    pipeline setup, eliminating parallel divergent configurations
+  - improved throughput of critical services through targeted profiling and optimisation
+  - participated in full life-cycle of features from product owner requests through
+    design to final implementation
 - project: monasca
   entries:
-  - developing backend services for log processing in OpenStack environment
-  - maintaining (and originally creating) monasca-log-api, monasca-kibana-plugin and
-    keystone-v3-client projects
-  - increasing code quality for monasca projects by influencing proper CI setup
-  - core-reviewer responsibilities within monasca organization at OpenStack Gerrit
-    service
-  - active collaborator and participant of monasca weekly and annual meetings
-  - maintaining and creating dockerized monasca-log pipeline for monasca-docker project
+  - authored monasca-log-api from scratch and maintained it as original owner, earning
+    OpenStack core-reviewer status — one of fewer than 10 across the monasca org
+  - eliminated log-pipeline setup friction for operators by building the dockerized
+    monasca-log pipeline for monasca-docker, adopted by the community
+  - increased code quality for monasca projects by influencing proper CI setup
 - project: OpenService Catalog Manager
   entries:
-  - migrating the monolithic application from Glassfish 2.x to Glassfish 3.x
-  - adjusting both backend and frontend side of aforementioned application
+  - unblocked the team from a deprecated runtime by migrating OSCm from Glassfish 2.x
+    to Glassfish 3.x, keeping backend and frontend in sync throughout

--- a/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
+++ b/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
@@ -8,27 +8,31 @@ tasks:
   entries:
   - delivered reproducible multi-service AWS infrastructure (EMR, MSK, EC2 HA) using
     CloudFormation + Makefile orchestration, replacing manual cluster setup
-  - enforced CloudFormation code-quality gates project-wide, catching configuration
+  - enforced CloudFormation code-quality gates project-wide to catch configuration
     drift before it reached production
-  - stack spanned HA VPC networking, EMR, MSK, and manually-provisioned EC2 clusters due to project security restrictions
+  - stack covered HA VPC networking, EMR, MSK, and manually-provisioned EC2 clusters
+    due to project security restrictions
 - project: AWS Project 1 [proprietary]
   entries:
   - reduced IAM blast radius across the deployment by applying least-privilege principles
     to every Lambda execution role, enforced through GitHub Actions CI gates
-  - serverless REST API (Lambda) and static UI (S3) deployed end-to-end with GitHub Actions CI/CD
+  - deployed a serverless REST API (Lambda) and static UI (S3) end-to-end with
+    GitHub Actions CI/CD
 - project: EOS
   entries:
   - accelerated CI adoption across backend and frontend teams by introducing a shared
-    pipeline setup, eliminating parallel divergent configurations
+    pipeline setup, removing the parallel divergent configurations they had before
   - improved throughput of critical services through targeted profiling and optimisation
-  - owned features end-to-end from product owner requirements through design to production, reducing handoff gaps
+  - owned features end-to-end from product owner requirements through design to
+    production, cutting handoff gaps along the way
 - project: monasca
   entries:
   - authored monasca-log-api from scratch and maintained it as original owner, earning
-    OpenStack core-reviewer status — one of fewer than 10 across the monasca org
+    OpenStack core-reviewer status, one of fewer than 10 across the monasca org
   - eliminated log-pipeline setup friction for operators by building the dockerized
-    monasca-log pipeline for monasca-docker, adopted by the community
-  - raised monasca project CI standards by introducing gating pipelines that blocked merges on quality regressions
+    monasca-log pipeline for monasca-docker, which the community adopted
+  - raised monasca project CI standards by introducing gating pipelines that blocked
+    merges on quality regressions
 - project: OpenService Catalog Manager
   entries:
   - unblocked the team from a deprecated runtime by migrating OSCm from Glassfish 2.x

--- a/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
+++ b/data/experience/fujitsu-technology-solutions-sp-z-oo.yml
@@ -23,6 +23,8 @@ tasks:
   - accelerated CI adoption across backend and frontend teams by introducing a shared
     pipeline setup, removing the parallel divergent configurations they had before
   - improved throughput of critical services through targeted profiling and optimisation
+  - drove API governance proposals adopted by both backend and frontend teams,
+    covering design standards and long-term maintenance strategy
   - owned features end-to-end from product owner requirements through design to
     production, cutting handoff gaps along the way
 - project: monasca

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -18,6 +18,9 @@ tasks:
     OAuth2/Cognito + CloudFront + ALB + ECS Fargate MCP server infrastructure
   - replaced ad-hoc deployment steps with CDK-based IaC for the complete agentic
     workflow, from provisioning to teardown
+  - orchestrated systems of 5+ specialised agents, each scoped to a task domain
+    and equipped with selected MCP servers — coordination handled programmatically,
+    not by a single monolithic agent
 - project: (Gen)AI/ML
   entries:
   - drove 10+ R&D GenAI projects end-to-end, from client problem framing through

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -9,32 +9,30 @@ tasks:
   - improved client business operations planning by implementing Timefold solver
     for NP-hard scheduling constraints, replacing manual planning steps
   - modelled problem constraints per customer requirements in Java-based ecosystem
-- project: Agentic AI on AWS
+- project: (Gen)AI on AWS
   entries:
+  - drove 10+ R&D GenAI projects end-to-end, from client problem framing through
+    architecture and cost analysis to POC or production handoff — several projects
+    adopted and taken forward by clients after delivery
+  - built a GenAI-powered call centre on Amazon Connect + Bedrock, routing contacts
+    through a knowledge-base-connected agent and escalating to human agents only
+    when needed
   - delivered production-grade agentic AI systems on AWS Bedrock AgentCore to
-    multiple clients, responsible for the full stack from cross-account IAM
-    chaining to MCP server infrastructure
-  - eliminated manual auth wiring for every new agent integration by deploying
-    OAuth2/Cognito + CloudFront + ALB + ECS Fargate MCP server infrastructure
+    multiple clients — agents invoked by external systems and integrations, with
+    CDK-managed infrastructure end to end
+  - deployed AWS AgentCore Gateway as a managed MCP entry point with Cognito JWT
+    auth, exposing multiple MCP server runtimes through a single endpoint; added
+    OAuth 2.1 PKCE flow so human operators could connect via Claude Code without
+    separate credential management
+  - implemented cross-account IAM chaining with session tags per client, giving
+    agents scoped access to client AWS accounts with no standing permissions and
+    no cross-tenant leakage
   - replaced ad-hoc deployment steps with CDK-based IaC for the complete agentic
     workflow, from provisioning to teardown
   - orchestrated systems of 5+ specialised agents, each scoped to a task domain
     and equipped with selected MCP servers — coordination handled programmatically,
     not by a single monolithic agent
-- project: (Gen)AI/ML
-  entries:
-  - drove 10+ R&D GenAI projects end-to-end, from client problem framing through
-    architecture and cost analysis to POC or production handoff
-  - cut evaluation cycle time for agentic RAG and multi-agent systems by building
-    reusable LLM evaluation pipelines, so clients had decision-quality signals
-    before they needed them
-  - built multi-tenant MCP server tooling with credential-aware proxies; each
-    client got isolated AWS-integrated access with no credential leakage
 - project: internal
   entries:
-  - eliminated credential sprawl by designing IAM architecture and building credential
-    management tooling that standardised access patterns across the organisation
-  - reduced integration boilerplate by standardising webhook validation, EventBridge
-    routing, and Snowflake data pipeline patterns for reuse across projects
-  - caught infrastructure drift earlier by building CloudFormation resource
-    monitoring and security audit tooling
+  - built a browser extension to bridge incompatible ticketing systems, removing
+    manual cross-system work for the team

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -11,8 +11,12 @@ tasks:
   - modelled problem constraints per customer requirements in Java-based ecosystem
 - project: (Gen)AI on AWS
   entries:
-  - drove 10+ R&D GenAI projects from problem framing through architecture and cost
-    analysis to handoff; several were adopted and extended by clients after delivery
+  - founded the AI agent platform with first cross-account access proof-of-concept
+    (October 2025), contributing 45% of all commits across infrastructure, backend
+    services, agent runtime, shared libraries, and chat interface layers
+  - drove 10+ R&D GenAI projects for clients across multiple industries, from problem
+    framing through architecture and cost analysis to handoff; several were adopted
+    and extended by clients after delivery
   - built a GenAI-powered call centre on Amazon Connect + Bedrock, with a
     knowledge-base-connected agent filtering routine contacts before escalation to a human
   - delivered agentic AI systems on AWS Bedrock AgentCore to multiple clients; agents
@@ -20,12 +24,16 @@ tasks:
     infrastructure lifecycle
   - deployed AWS AgentCore Gateway as the MCP entry point with Cognito JWT auth,
     routing requests to multiple MCP server runtimes; added OAuth 2.1 PKCE so human
-    operators could connect via Claude Code without managing separate credentials
+    operators could connect via Claude Code without managing separate credentials,
+    then built chat interface integration (handler, IaC, user commands) to expose
+    agents to broader, less technical audience via the company messaging platform
   - implemented cross-account IAM chaining with session tags scoped per client, so
     each agent's access was limited to that client's accounts with nothing shared
     across tenants
   - replaced ad-hoc deployment steps with CDK IaC covering the full agentic workflow
     lifecycle
+  - designed image build fingerprinting system that fixed a class of stale cache bugs
+    when shared library dependencies changed
   - orchestrated 5+ specialised agents, each focused on a specific task domain with
     its own set of MCP servers; the coordination layer was programmatic, not a single
     general-purpose agent

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -11,8 +11,8 @@ tasks:
   - modelled problem constraints per customer requirements in Java-based ecosystem
 - project: Agentic AI on AWS
   entries:
-  - delivered production-grade agentic AI systems to multiple clients, covering
-    the full stack from cross-account IAM chaining to MCP server infrastructure
+  - delivered production-grade agentic AI systems on AWS Bedrock AgentCore to multiple
+    clients, covering the full stack from cross-account IAM chaining to MCP server infrastructure
   - eliminated manual auth wiring for every new agent integration by deploying
     OAuth2/Cognito + CloudFront + ALB + ECS Fargate MCP server infrastructure
   - replaced ad-hoc deployment steps with CDK-based IaC covering the full agentic
@@ -23,6 +23,8 @@ tasks:
     through architecture and cost analysis to POC or production handoff
   - cut evaluation cycle time for agentic RAG and multi-agent systems by building
     reusable LLM evaluation pipelines, giving clients decision-quality signals earlier
+  - built MCP server tooling including credential-aware proxies and AWS-integrated
+    servers, adopted across client and internal agentic deployments
 - project: internal
   entries:
   - eliminated credential sprawl by designing IAM architecture and building credential

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -11,28 +11,25 @@ tasks:
   - modelled problem constraints per customer requirements in Java-based ecosystem
 - project: (Gen)AI on AWS
   entries:
-  - drove 10+ R&D GenAI projects end-to-end, from client problem framing through
-    architecture and cost analysis to POC or production handoff — several projects
-    adopted and taken forward by clients after delivery
-  - built a GenAI-powered call centre on Amazon Connect + Bedrock, routing contacts
-    through a knowledge-base-connected agent and escalating to human agents only
-    when needed
-  - delivered production-grade agentic AI systems on AWS Bedrock AgentCore to
-    multiple clients — agents invoked by external systems and integrations, with
-    CDK-managed infrastructure end to end
-  - deployed AWS AgentCore Gateway as a managed MCP entry point with Cognito JWT
-    auth, exposing multiple MCP server runtimes through a single endpoint; added
-    OAuth 2.1 PKCE flow so human operators could connect via Claude Code without
-    separate credential management
-  - implemented cross-account IAM chaining with session tags per client, giving
-    agents scoped access to client AWS accounts with no standing permissions and
-    no cross-tenant leakage
-  - replaced ad-hoc deployment steps with CDK-based IaC for the complete agentic
-    workflow, from provisioning to teardown
-  - orchestrated systems of 5+ specialised agents, each scoped to a task domain
-    and equipped with selected MCP servers — coordination handled programmatically,
-    not by a single monolithic agent
+  - drove 10+ R&D GenAI projects from problem framing through architecture and cost
+    analysis to handoff; several were adopted and extended by clients after delivery
+  - built a GenAI-powered call centre on Amazon Connect + Bedrock, with a
+    knowledge-base-connected agent filtering routine contacts before escalation to a human
+  - delivered agentic AI systems on AWS Bedrock AgentCore to multiple clients; agents
+    were invoked by external systems and integrations, with CDK managing the full
+    infrastructure lifecycle
+  - deployed AWS AgentCore Gateway as the MCP entry point with Cognito JWT auth,
+    routing requests to multiple MCP server runtimes; added OAuth 2.1 PKCE so human
+    operators could connect via Claude Code without managing separate credentials
+  - implemented cross-account IAM chaining with session tags scoped per client, so
+    each agent's access was limited to that client's accounts with nothing shared
+    across tenants
+  - replaced ad-hoc deployment steps with CDK IaC covering the full agentic workflow
+    lifecycle
+  - orchestrated 5+ specialised agents, each focused on a specific task domain with
+    its own set of MCP servers; the coordination layer was programmatic, not a single
+    general-purpose agent
 - project: internal
   entries:
-  - built a browser extension to bridge incompatible ticketing systems, removing
-    manual cross-system work for the team
+  - built a browser extension to bridge two incompatible ticketing systems, eliminating
+    manual data copying between them

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -6,24 +6,28 @@ city: Warsaw, Poland
 tasks:
 - project: NP problems
   entries:
-  - working with Timefold solver
-  - solving NP-hard problem according to customer's needs
-  - Java based ecosystem
+  - improved client business operations planning by implementing Timefold solver
+    for NP-hard scheduling constraints, replacing manual planning steps
+  - modelled problem constraints per customer requirements in Java-based ecosystem
 - project: Agentic AI on AWS
   entries:
-  - designing and building multi-agent systems on AWS Bedrock AgentCore
-  - cross-account IAM chaining enabling agents to operate across AWS accounts securely
-  - MCP server infrastructure with OAuth2/Cognito authentication, CloudFront, ALB, ECS Fargate
-  - CDK-based IaC for full agentic workflow deployment lifecycle
-  - Python, serverless-first, production-grade
+  - delivered production-grade agentic AI systems to multiple clients, covering
+    the full stack from cross-account IAM chaining to MCP server infrastructure
+  - eliminated manual auth wiring for every new agent integration by deploying
+    OAuth2/Cognito + CloudFront + ALB + ECS Fargate MCP server infrastructure
+  - replaced ad-hoc deployment steps with CDK-based IaC covering the full agentic
+    workflow lifecycle, from provisioning to teardown
 - project: (Gen)AI/ML
   entries:
-  - architecture design and cost analysis for GenAI commercial projects
-  - LLM evaluation pipelines for agentic RAG and multi-agent systems
-  - MCP server tooling including credential-aware proxies and AWS-integrated servers
-  - Python, TypeScript
+  - delivered 10+ R&D GenAI projects end-to-end — from client problem framing
+    through architecture and cost analysis to POC or production handoff
+  - cut evaluation cycle time for agentic RAG and multi-agent systems by building
+    reusable LLM evaluation pipelines, giving clients decision-quality signals earlier
 - project: internal
   entries:
-  - IAM architecture, credential management tooling, and developer experience improvements
-  - event-driven integrations (webhook validation, EventBridge routing, data pipelines to Snowflake)
-  - security audit tooling and CloudFormation resource monitoring
+  - eliminated credential sprawl by designing IAM architecture and building credential
+    management tooling that standardised access patterns across the organisation
+  - reduced integration boilerplate by standardising webhook validation, EventBridge
+    routing, and Snowflake data pipeline patterns for reuse across projects
+  - improved visibility into infrastructure drift by building CloudFormation resource
+    monitoring and security audit tooling

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -23,8 +23,8 @@ tasks:
     through architecture and cost analysis to POC or production handoff
   - cut evaluation cycle time for agentic RAG and multi-agent systems by building
     reusable LLM evaluation pipelines, giving clients decision-quality signals earlier
-  - built MCP server tooling including credential-aware proxies and AWS-integrated
-    servers, adopted across client and internal agentic deployments
+  - built multi-tenant MCP server tooling with credential-aware proxies, enabling
+    isolated AWS-integrated access per client without credential leakage
 - project: internal
   entries:
   - eliminated credential sprawl by designing IAM architecture and building credential

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -11,25 +11,27 @@ tasks:
   - modelled problem constraints per customer requirements in Java-based ecosystem
 - project: Agentic AI on AWS
   entries:
-  - delivered production-grade agentic AI systems on AWS Bedrock AgentCore to multiple
-    clients, covering the full stack from cross-account IAM chaining to MCP server infrastructure
+  - delivered production-grade agentic AI systems on AWS Bedrock AgentCore to
+    multiple clients, responsible for the full stack from cross-account IAM
+    chaining to MCP server infrastructure
   - eliminated manual auth wiring for every new agent integration by deploying
     OAuth2/Cognito + CloudFront + ALB + ECS Fargate MCP server infrastructure
-  - replaced ad-hoc deployment steps with CDK-based IaC covering the full agentic
-    workflow lifecycle, from provisioning to teardown
+  - replaced ad-hoc deployment steps with CDK-based IaC for the complete agentic
+    workflow, from provisioning to teardown
 - project: (Gen)AI/ML
   entries:
-  - delivered 10+ R&D GenAI projects end-to-end — from client problem framing
-    through architecture and cost analysis to POC or production handoff
+  - drove 10+ R&D GenAI projects end-to-end, from client problem framing through
+    architecture and cost analysis to POC or production handoff
   - cut evaluation cycle time for agentic RAG and multi-agent systems by building
-    reusable LLM evaluation pipelines, giving clients decision-quality signals earlier
-  - built multi-tenant MCP server tooling with credential-aware proxies, enabling
-    isolated AWS-integrated access per client without credential leakage
+    reusable LLM evaluation pipelines, so clients had decision-quality signals
+    before they needed them
+  - built multi-tenant MCP server tooling with credential-aware proxies; each
+    client got isolated AWS-integrated access with no credential leakage
 - project: internal
   entries:
   - eliminated credential sprawl by designing IAM architecture and building credential
     management tooling that standardised access patterns across the organisation
   - reduced integration boilerplate by standardising webhook validation, EventBridge
     routing, and Snowflake data pipeline patterns for reuse across projects
-  - improved visibility into infrastructure drift by building CloudFormation resource
+  - caught infrastructure drift earlier by building CloudFormation resource
     monitoring and security audit tooling

--- a/data/experience/lcloud.yml
+++ b/data/experience/lcloud.yml
@@ -33,3 +33,7 @@ tasks:
   entries:
   - built a browser extension to bridge two incompatible ticketing systems, eliminating
     manual data copying between them
+  - built a multi-agent pull request review workflow as Claude Code skills;
+    difficulty-tiered subagent dispatch (haiku/sonnet/opus), shared JSON
+    schema contracts between skills, and Jira integration for deferred findings
+    topped with HTML render for human interactions

--- a/data/skills/ai.yml
+++ b/data/skills/ai.yml
@@ -4,3 +4,4 @@ subskill:
 - Agents
 - Prompt engineering
 - Knowledge bases
+- Claude

--- a/data/skills/backend.yml
+++ b/data/skills/backend.yml
@@ -1,7 +1,6 @@
 category: Backend
 subskill:
 - Python 3.x
-- Python 2.x
 - SQL
 - OpenAPI (Swagger)
 - Java

--- a/data/skills/cicd.yml
+++ b/data/skills/cicd.yml
@@ -1,8 +1,5 @@
 category: CICD
 subskill:
 - CircleCI
-- Travis
-- Gerrit
 - Github Actions
 - Gitlab CI
-- Bitbucket pipelines

--- a/data/skills/containers.yml
+++ b/data/skills/containers.yml
@@ -2,4 +2,4 @@ category: Containers
 subskill:
 - docker
 - docker-compose
-- k8s (familiar)
+- docker buildx

--- a/data/skills/general.yml
+++ b/data/skills/general.yml
@@ -1,7 +1,4 @@
 category: General
 subskill:
-- team work
-- communicative
-- like challenges
-- interdisciplinary
-- automation
+  - technical leadership (led backend teams at AppYourself and Fujitsu)
+  - automation (CDK, GitHub Actions, Makefile — applied across three organisations)

--- a/template/cv.tex
+++ b/template/cv.tex
@@ -38,7 +38,9 @@ $endfor$
 
 $if(basic.summary)$
 \cvsection{Summary}
+\begin{cvparagraph}
 $basic.summary$
+\end{cvparagraph}
 $endif$
 
 $if(education)$

--- a/template/cv.tex
+++ b/template/cv.tex
@@ -36,6 +36,11 @@ $endfor$
   {}
   {\thepage}
 
+$if(basic.summary)$
+\cvsection{Summary}
+$basic.summary$
+$endif$
+
 $if(education)$
 \cvsection{Education}
 \begin{cventries}

--- a/template/cv.tex
+++ b/template/cv.tex
@@ -38,6 +38,7 @@ $endfor$
 
 $if(basic.summary)$
 \cvsection{Summary}
+\par
 \begin{cvparagraph}
 $basic.summary$
 \end{cvparagraph}

--- a/template/cv.tex
+++ b/template/cv.tex
@@ -44,25 +44,6 @@ $basic.summary$
 \end{cvparagraph}
 $endif$
 
-$if(education)$
-\cvsection{Education}
-\begin{cventries}
-    $for(education)$
-    \cventry
-    {$education.faculty$}
-    {$education.school$}
-    {$education.city$}
-    {$education.years$}
-    $if(education.thesis)$
-    {Thesis: \textit{$education.thesis$}}
-    $else$
-    {}
-    $endif$
-    \vspace{5pt}
-    $endfor$
-\end{cventries}
-$endif$
-
 $if(experience)$
 \cvsection{Experience}
 \begin{cventries}
@@ -109,6 +90,25 @@ $for(skill)$
     }
 $endfor$
 \end{cvskills}
+$endif$
+
+$if(education)$
+\cvsection{Education}
+\begin{cventries}
+    $for(education)$
+    \cventry
+    {$education.faculty$}
+    {$education.school$}
+    {$education.city$}
+    {$education.years$}
+    $if(education.thesis)$
+    {Thesis: \textit{$education.thesis$}}
+    $else$
+    {}
+    $endif$
+    \vspace{5pt}
+    $endfor$
+\end{cventries}
 $endif$
 
 $if(presentation)$

--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -14,9 +14,11 @@ interface Props {
   position: string;
   photoUrl: string;
   social: Social[];
+  quote?: string;
+  summary?: string;
 }
 
-const { firstName, lastName, position, photoUrl, social } = Astro.props;
+const { firstName, lastName, position, photoUrl, social, quote, summary } = Astro.props;
 
 // Filter for GitHub and LinkedIn only
 const displaySocial = social.filter(s =>
@@ -121,6 +123,9 @@ for (let i = 0; i < shapeCount; i++) {
       <span class="name-alias">kornicameister</span>
     </h1>
     <p class="hero-position">{position}</p>
+    {(quote || summary) && <hr class="hero-divider" />}
+    {quote && <p class="hero-quote">"{quote}"</p>}
+    {summary && <p class="hero-summary">{summary}</p>}
     <div class="hero-social">
       {displaySocial.map(social => (
         <a
@@ -263,8 +268,31 @@ for (let i = 0; i < shapeCount; i++) {
   .hero-position {
     font-size: 1.5rem;
     color: rgba(255, 255, 255, 0.95);
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     font-weight: 300;
+  }
+
+  .hero-divider {
+    border: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.22);
+    width: 48px;
+    margin: 0 auto 1rem;
+  }
+
+  .hero-quote {
+    font-family: Georgia, serif;
+    font-style: italic;
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.88);
+    margin-bottom: 0.75rem;
+  }
+
+  .hero-summary {
+    font-size: 0.92rem;
+    color: rgba(255, 255, 255, 0.80);
+    max-width: 560px;
+    margin: 0 auto 2rem;
+    line-height: 1.7;
   }
 
   .hero-social {
@@ -301,6 +329,10 @@ for (let i = 0; i < shapeCount; i++) {
 
     .hero-position {
       font-size: 1.2rem;
+    }
+
+    .hero-summary {
+      font-size: 0.875rem;
     }
   }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -16,6 +16,8 @@ import cvData from '../data/cv.json';
     position={cvData.basic.position}
     photoUrl={cvData.basic.photoUrl}
     social={cvData.social}
+    quote={cvData.quote}
+    summary={cvData.basic.summary}
   />
   <Experience entries={cvData.experience} />
   <Certifications certs={cvData.cert} />


### PR DESCRIPTION
## Summary

Comprehensive rewrite of CV content focusing on measurable outcomes and impact:

- **Summary section**: Added professional summary highlighting 13+ years of backend/cloud experience with focus on agentic AI, team leadership, and IaC automation
- **Experience bullets rewritten**: Replaced context-heavy descriptions with outcome-focused bullets showing specific impact (reduced incidents, accelerated adoption, eliminated manual steps)
- **Skills pruned**: Removed outdated tools (Python 2.x, Travis, Gerrit, Bitbucket pipelines, k8s-familiar)
- **Skills added**: Claude (AI category), docker buildx (containers category)
- **PDF layout**: Moved Experience and Skills before Education for better recruiter scanning
- **Web display**: Summary now rendered in Hero component

All experience bullets now follow the pattern: action → measurable outcome → context, making impact immediately visible.

## Files changed

- `data/basic.yml` — added summary field
- `data/experience/*.yml` — rewritten all bullets with outcome focus
- `data/skills/*.yml` — pruned dead entries, added Claude and docker buildx
- `template/cv.tex` — added summary section, reordered sections
- `web/src/components/Hero.astro` — display summary in hero
- `web/src/pages/index.astro` — pass summary to Hero component

## Test plan

- [x] PDF builds without errors (`make cv.pdf`)
- [x] JSON builds without errors (`make cv.json`)
- [x] Summary renders in PDF
- [x] Summary renders on web
- [x] All experience bullets follow outcome-first pattern
- [x] Skills list reflects current toolset only